### PR TITLE
Bump `claranet/vm-logs/azurerm` to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Changed:
+  * GITHUB-2: Bump `claranet/vm-logs/azurerm` version to 4.2.0
+
 # v6.1.0 - 2022-06-24
 
 Added

--- a/r-diagnostics.tf
+++ b/r-diagnostics.tf
@@ -2,7 +2,7 @@ module "vm_logs" {
   for_each = toset(var.use_legacy_monitoring_agent ? ["enabled"] : [])
 
   source  = "claranet/vm-logs/azurerm"
-  version = "4.1.0"
+  version = "4.2.0"
 
   environment = var.environment
   stack       = var.stack


### PR DESCRIPTION
Following https://github.com/claranet/terraform-azurerm-vm-logs/pull/2